### PR TITLE
Add cdvirtualenv: cd to current active virtualenv

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -16,6 +16,7 @@ A Fish Shell wrapper for Ian Bicking's virtualenv, somewhat loosely based on Dou
 * `mkvirtualenv [<options>] <envname>` - Create a virtualenv. Note that `<envname>` *must be last*.
 * `rmvirtualenv <envname>` - Delete a virtualenv.
 * `lsvirtualenv` - List the available virtualenvs.
+* `cdvirtualenv` - Change directory to currently-activated virtualenv.
 
 \*with `VIRTUALFISH_COMPAT_ALIASES` switched on - see Configuration Variables below.
 

--- a/virtual.fish
+++ b/virtual.fish
@@ -109,6 +109,14 @@ function lsvirtualenv --description "List all of the available virtualenvs"
 	popd
 end
 
+function cdvirtualenv --description "Change directory to currently-activated virtualenv"
+    if set -q VIRTUAL_ENV
+        cd $VIRTUAL_ENV
+    else
+        echo "Cannot locate an active virtualenv."
+    end 
+end
+
 # Autocomplete
 complete -x -c acvirtualenv -a "(lsvirtualenv)"
 complete -x -c rmvirtualenv -a "(lsvirtualenv)"


### PR DESCRIPTION
virtualenvwrapper has a cdvirtualenv command that changes the directory
to the currently-active virtualenv (if any). This commit adds a function
to do the same for virtualfish.
