### PR TITLE
Functions are faster & more reliable than aliases

### DIFF
--- a/virtual.fish
+++ b/virtual.fish
@@ -6,8 +6,12 @@ if not set -q VIRTUALFISH_HOME
 end
 
 if set -q VIRTUALFISH_COMPAT_ALIASES
-	alias workon acvirtualenv
-	alias deactivate devirtualenv
+        function workon
+                acvirtualenv $argv[1]
+        end
+        function deactivate
+                devirtualenv
+        end
 end
 
 function acvirtualenv --description "Activate a virtualenv"


### PR DESCRIPTION
As noted in the [fish documentation](http://fishshell.com/docs/2.0/commands.html#alias), the "alias" command exists for
backwards compatibility with POSIX shells and usually isn't the best
method for aliasing commands. There have also been performance issues
with the "alias" command, as noted in the fish issue tracker:
https://github.com/fish-shell/fish-shell/issues/486

In general, fish functions are more reliable and provide better
performance.
