### PR TITLE
Support custom auto-activation files. Fixes #5.

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -23,9 +23,13 @@ A Fish Shell wrapper for Ian Bicking's virtualenv, somewhat loosely based on Dou
 
 ### Automatic Activation
 
-virtualfish can automatically activate a virtualenv when you are in a certain directory. To configure it to do so, place a file inside the directory called `.vfenv`, containing the name of the virtualenv.
+virtualfish can automatically activate a virtualenv when you are in a certain directory. To configure it to do so, place a file inside the directory called `.venv`, containing the name of the virtualenv.
 
-    $ echo myvirtualenvname > .vfenv
+    $ echo myvirtualenvname > .venv
+
+If you would prefer to use a different name for this file, you can do so provided you also set `VIRTUALFISH_ACTIVATION_FILE` in `~/.config/fish/config.fish` to the same value. For example:
+
+	set -gx VIRTUALFISH_ACTIVATION_FILE .vfenv
 
 ### Variables
 
@@ -64,6 +68,7 @@ The full list of events is:
 All of these must be set before `virtual.fish` is sourced in your `~/.config/fish/config.fish`.
 
 * `VIRTUALFISH_HOME` (default: `~/.virtualenvs`) - where all your virtualenvs are kept.
+* `VIRTUALFISH_ACTIVATION_FILE` (default: `.venv`) - the name of the file virtualfish will use for the auto-activation feature.
 * `VIRTUALFISH_COMPAT_ALIASES` - set this to create aliases for `workon` and `deactivate` a la virtualenvwrapper. *Caveat: `deactivate` exists (and can be overwritten) even when a virtualenv is not active.*
 
 ### Customizing Your `fish_prompt`

--- a/virtual.fish
+++ b/virtual.fish
@@ -5,6 +5,10 @@ if not set -q VIRTUALFISH_HOME
 	set -g VIRTUALFISH_HOME $HOME/.virtualenvs
 end
 
+if not set -q VIRTUALFISH_ACTIVATION_FILE
+	set -g VIRTUALFISH_ACTIVATION_FILE .venv
+end
+
 if set -q VIRTUALFISH_COMPAT_ALIASES
         function workon
                 acvirtualenv $argv[1]
@@ -128,7 +132,7 @@ end
 
 function connvirtualenv --description "Connect this virtualenv to the current directory"
 	if set -q VIRTUAL_ENV
-		basename $VIRTUAL_ENV > .vfenv
+		basename $VIRTUAL_ENV > $VIRTUALFISH_ACTIVATION_FILE
 	else
 		echo "No virtualenv is active."
 	end
@@ -144,16 +148,16 @@ function __vf_auto_activate --on-variable PWD
 		return
 	end
 			
-	# find a .vfenv file
+	# find an auto-activation file
 	set -l vfeloc $PWD
-	while test ! "$vfeloc" = "" -a ! -f "$vfeloc/.vfenv"
+	while test ! "$vfeloc" = "" -a ! -f "$vfeloc/$VIRTUALFISH_ACTIVATION_FILE"
 		# this strips the last path component from the path.
 		set vfeloc (echo "$vfeloc" | sed 's|/[^/]*$||')
 	end	
 		
 	set -l newve			
-	if [ -f "$vfeloc/.vfenv" ]
-		set newve (cat "$vfeloc/.vfenv")
+	if [ -f "$vfeloc/$VIRTUALFISH_ACTIVATION_FILE" ]
+		set newve (cat "$vfeloc/$VIRTUALFISH_ACTIVATION_FILE")
 	end				
 	
 	# apply new venv if changed


### PR DESCRIPTION
This changes the default auto-activation filename from .vfenv to the
more standard .venv, while at the same time providing a setting that
can be used to customize this filename to any arbitrary value. For any
folk who already have .vfenv files, this setting can be used to provide
backwards compatibility.
