### PR TITLE
Avoid hardcoding pip cache directory

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -74,6 +74,15 @@ All of these must be set before `virtual.fish` is sourced in your `~/.config/fis
 * `VIRTUALFISH_ACTIVATION_FILE` (default: `.venv`) - the name of the file virtualfish will use for the auto-activation feature.
 * `VIRTUALFISH_COMPAT_ALIASES` - set this to create aliases for `workon` and `deactivate` a la virtualenvwrapper. *Caveat: `deactivate` exists (and can be overwritten) even when a virtualenv is not active.*
 
+If you have pip 1.4+ and have used `vf requirements` to add global requirements that should be installed in all your virtual environments, adding the following configuration variables to `~/.config/fish/config.fish` will significantly speed up the installation process:
+
+    set -x PIP_USE_WHEEL "true"
+    set -x PIP_WHEEL_DIR "$HOME/.pip/wheels"
+    set -x PIP_FIND_LINKS "$HOME/.pip/wheels"
+    set -x PIP_DOWNLOAD_CACHE "$HOME/.pip/cache"
+
+These are standard pip settings and aren't directly related to virtualfish. The wheels and cache paths can be set to any arbitrary directories you prefer.
+
 ### Customizing Your `fish_prompt`
 virtualfish doesn't attempt to mess with your prompt. Since Fish's prompt is a function, it is both much less straightforward to change it automatically, and much more convenient to simply customize it manually to your liking.
 

--- a/virtual.fish
+++ b/virtual.fish
@@ -112,7 +112,7 @@ function __vf_new --description "Create a new virtualenv"
 	if [ $vestatus -eq 0 ]; and [ -d $VIRTUALFISH_HOME/$envname ]
 		vf activate $envname
         if test -f $VIRTUALFISH_HOME/global_requirements.txt
-            pip install --download-cache $VIRTUALFISH_HOME/_pip_cache -r $VIRTUALFISH_HOME/global_requirements.txt
+            pip install -r $VIRTUALFISH_HOME/global_requirements.txt
         end
 	else
 		echo "Error: The virtualenv wasn't created properly."
@@ -162,7 +162,7 @@ function __vf_requirements --description "Edit the global requirements file for 
     eval $EDITOR $VIRTUALFISH_HOME/global_requirements.txt
     pushd $VIRTUALFISH_HOME
     for i in */bin/pip
-        eval $i install --download-cache $VIRTUALFISH_HOME/_pip_cache -r $VIRTUALFISH_HOME/global_requirements.txt
+        eval $i install -r $VIRTUALFISH_HOME/global_requirements.txt
     end
 end
 


### PR DESCRIPTION
Hardcoding the cache values in 221954d (i.e., `--download-cache
$VIRTUALFISH_HOME/_pip_cache`) will likely override the user's pip
configuration settings. In my case, I have the following in
`config.fish`:

```
set -x PIP_DOWNLOAD_CACHE "$HOME/.pip/cache"
```

If I already have a metric ton of cached packages in
`$HOME/.pip/cache` (and I do), why would I want or need another
cache created in `$VIRTUALFISH_HOME/_pip_cache`?

(In case you're wondering, "Maybe Virtualfish should look for these
environment variables, and if they aren't found, fall back to
defaults such as `$VIRTUALFISH_HOME/_pip_cache`?" ... that would
still potentially cause problems because pip configuration can also
be stored in `~/.pip/pip.conf`.)

This commit removes the hardcoded values and instead provides
instructions in the README that explain how to use pip's cache and wheel
settings to speed up global requirements installations.
