### PR TITLE
Fix begin statements in compound if clauses.

### DIFF
--- a/auto_activation.fish
+++ b/auto_activation.fish
@@ -25,7 +25,7 @@ function __vfsupport_auto_activate --on-variable PWD
 
     if test $new_virtualenv_name != ""
         # if the virtualenv in the file is different, switch to it
-        if begin not set -q VIRTUAL_ENV; or test $new_virtualenv_name != (basename $VIRTUAL_ENV); end
+        if begin; not set -q VIRTUAL_ENV; or test $new_virtualenv_name != (basename $VIRTUAL_ENV); end
             vf activate $new_virtualenv_name
             set -g VF_AUTO_ACTIVATED $activation_root
         end

--- a/virtual.fish
+++ b/virtual.fish
@@ -135,7 +135,7 @@ function __vf_new --description "Create a new virtualenv"
 	set -e argv[-1]
 	virtualenv $argv $VIRTUALFISH_HOME/$envname
 	set vestatus $status
-	if begin [ $vestatus -eq 0 ]; and [ -d $VIRTUALFISH_HOME/$envname ]; end
+	if begin; [ $vestatus -eq 0 ]; and [ -d $VIRTUALFISH_HOME/$envname ]; end
 		vf activate $envname
         emit virtualenv_did_create
         emit virtualenv_did_create:(basename $VIRTUAL_ENV)
@@ -151,7 +151,7 @@ function __vf_rm --description "Delete a virtualenv"
 		echo "You need to specify exactly one virtualenv."
 		return 1
 	end
-	if begin set -q VIRTUAL_ENV; and [ $argv[1] = (basename $VIRTUAL_ENV) ]; end
+	if begin; set -q VIRTUAL_ENV; and [ $argv[1] = (basename $VIRTUAL_ENV) ]; end
 		echo "You can't delete a virtualenv you're currently using."
 		return 1
 	end


### PR DESCRIPTION
5dcb1fe7057 introduced a number of begin statements that are missing a
semicolon. Although these work in fish 2.1.0 and earlier, later
development introduces a new parser that treats arguments to begin as an
error (in line with the documentation).

Bringing the begin statements into line with the documentation keeps
them working on all versions of fish.

(See https://github.com/fish-shell/fish-shell/issues/1248 for
discussion.)
