### PR TITLE
bug workaround when saving an event handler

### DIFF
--- a/docs/extend.rst
+++ b/docs/extend.rst
@@ -25,9 +25,9 @@ to events that virtualfish emits, write a function like this:
         echo "The virtualenv" (basename $VIRTUAL_ENV) "was activated"
     end
 
-You can save your function using ``funcsave``, put it in
-``.config/fish/config.fish``, or put it anywhere Fish will see it before
-it needs to run.
+You can define your function in ``.config/fish/config.fish``. Do not use ``funced`` 
+and ``funcsave`` for the event handlers. Functions saved using ``funcsave`` are not handling 
+events due to a Fish shell `bug <https://github.com/fish-shell/fish-shell/issues/845>`_.
 
 Some events are emitted twice, once normally and once with the name of
 the virtualenv as part of the event name. This is to make it easier to


### PR DESCRIPTION
Due to https://github.com/fish-shell/fish-shell/issues/845 the functions handling events are not activated upon load. Funcsave of the event handlers doesn't lead to proper results and should be avoided.
