### PR TITLE
Install/Upgrade global_requirements

### DIFF
--- a/global_requirements.fish
+++ b/global_requirements.fish
@@ -1,6 +1,6 @@
 function __vfext_global_requirements --on-event virtualenv_did_create
     if test -f $VIRTUALFISH_HOME/global_requirements.txt
-        pip install -r $VIRTUALFISH_HOME/global_requirements.txt
+        pip install -U -r $VIRTUALFISH_HOME/global_requirements.txt
     end
 end
 


### PR DESCRIPTION
If the global_requirements is used to keep the package updated,
for example the pip and setuptools, only install the packages
will not work.