### PR TITLE
feat(toplevel): add vf help subcommand + improve documentation consistency/look

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -1,6 +1,6 @@
 # virtualfish
 
-A Fish Shell wrapper for Ian Bicking's virtualenv, somewhat loosely based on Doug Hellman's virtualenvwrapper for Bourne-compatible shells.
+A Fish Shell wrapper for Ian Bicking's [virtualenv](https://virtualenv.pypa.io/en/latest/), somewhat loosely based on Doug Hellman's [virtualenvwrapper](https://bitbucket.org/dhellmann/virtualenvwrapper) for Bourne-compatible shells.
 
 You can get started by [reading the documentation on Read The Docs](http://virtualfish.readthedocs.org/en/latest/). (It's quite short, I promise.)
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,8 +1,8 @@
 virtualfish
 ===========
 
-A Fish Shell wrapper for Ian Bicking's virtualenv, somewhat loosely
-based on Doug Hellman's virtualenvwrapper for Bourne-compatible shells.
+A Fish Shell wrapper for Ian Bicking's `virtualenv <https://virtualenv.pypa.io/en/latest/>`_, somewhat loosely
+based on Doug Hellman's `virtualenvwrapper <https://bitbucket.org/dhellmann/virtualenvwrapper>`_ for Bourne-compatible shells.
 
 Contents
 --------

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -15,7 +15,7 @@ Commands
    the currently-activated virtualenv's site-packages.
 -  ``vf deactivate`` (or ``deactivate``\ \*) - Deactivate the currently-activated
    virtualenv.
--  ``vf help`` - Print usage information
+-  ``vf help (or `vf --help` or `vf -h`)`` - Print usage information
 -  ``vf ls`` - List the available virtualenvs.
 -  ``vf new [<options>] <envname>`` (or ``mkvirtualenv``\ \*) - Create a
    virtualenv. Note that ``<envname>`` *must be last*.

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -7,21 +7,22 @@ Commands
 -  ``vf activate <envname>`` (or ``workon <envname>``\ \*) - Activate a
    virtualenv. (Note: Doesn't use the ``activate.fish`` script provided
    by virtualenv.)
--  ``vf deactivate`` (or ``deactivate``\ \*) - Deactivate the current
-   virtualenv.
--  ``vf new [<options>] <envname>`` (or ``mkvirtualenv``\ \*) - Create a
-   virtualenv. Note that ``<envname>`` *must be last*.
--  ``vf tmp [<options>]`` (or ``mktmpenv``\ \*) - Create a temprorary
-   virtualenv with a randomly generated name that will be removed when
-   it is deactivated.
--  ``vf rm <envname>`` (or ``rmvirtualenv``\ \*) - Delete a virtualenv.
--  ``vf ls`` - List the available virtualenvs.
--  ``vf cd`` (or ``cdvirtualenv``\ \*) - Change directory to
+-  ``vf addpath`` (or ``add2virtualenv``\ \*) - Add a directory to the currently-activated
+   virtualenv's ``sys.path``.
+-  ``vf cd`` (or ``cdvirtualenv``\ \*) - Change directory to the
    currently-activated virtualenv.
 -  ``vf cdpackages`` (or ``cdsitepackages``\ \*) - Change directory to
    the currently-activated virtualenv's site-packages.
--  ``vf addpath`` (or ``add2virtualenv``\ \*) - Add a directory to this
-   virtualenv's ``sys.path``.
+-  ``vf deactivate`` (or ``deactivate``\ \*) - Deactivate the currently-activated
+   virtualenv.
+-  ``vf help`` - Print usage information
+-  ``vf ls`` - List the available virtualenvs.
+-  ``vf new [<options>] <envname>`` (or ``mkvirtualenv``\ \*) - Create a
+   virtualenv. Note that ``<envname>`` *must be last*.
+-  ``vf rm <envname>`` (or ``rmvirtualenv``\ \*) - Delete a virtualenv.
+-  ``vf tmp [<options>]`` (or ``mktmpenv``\ \*) - Create a temporary
+   virtualenv with a randomly generated name that will be removed when
+   it is deactivated.
 
 \*with ``VIRTUALFISH_COMPAT_ALIASES`` switched on - see Configuration
 Variables below.

--- a/virtual.fish
+++ b/virtual.fish
@@ -54,7 +54,7 @@ function vf --description "VirtualFish: fish plugin to manage virtualenvs"
 	set -l funcname "__vf_$sc"
 	set -l scargs
 
-	if test (count $argv) -eq 0
+	if begin; [ (count $argv) -eq 0 ]; or [ $sc = "--help" ]; or [ $sc = "-h" ]; end
 		# If called without arguments, print usage
 		vf help
 		return

--- a/virtual.fish
+++ b/virtual.fish
@@ -56,14 +56,7 @@ function vf --description "VirtualFish: fish plugin to manage virtualenvs"
 
 	if test (count $argv) -eq 0
 		# If called without arguments, print usage
-		echo "Usage: vf <command> [<args>]"
-		echo
-		echo "Available commands:"
-		echo
-		for sc in (functions -a | sed -n '/__vf_/{s///g;p;}')
-			set -l helptext (functions "__vf_$sc" | head -n 1 | sed -E "s|.*'(.*)'.*|\1|")
-			printf "    %-15s %s\n" $sc (set_color 555)$helptext(set_color normal)
-		end
+		vf help
 		return
 	end
 
@@ -115,7 +108,7 @@ function __vf_activate --description "Activate a virtualenv"
 	emit virtualenv_did_activate:(basename $VIRTUAL_ENV)
 end
 
-function __vf_deactivate --description "Deactivate the currently-activated virtualenv"
+function __vf_deactivate --description "Deactivate this virtualenv"
 
 	emit virtualenv_will_deactivate
 	emit virtualenv_will_deactivate:(basename $VIRTUAL_ENV)
@@ -183,7 +176,7 @@ function __vf_ls --description "List all of the available virtualenvs"
 	popd
 end
 
-function __vf_cd --description "Change directory to currently-activated virtualenv"
+function __vf_cd --description "Change directory to this virtualenv"
     if set -q VIRTUAL_ENV
         cd $VIRTUAL_ENV
     else
@@ -191,12 +184,12 @@ function __vf_cd --description "Change directory to currently-activated virtuale
     end
 end
 
-function __vf_cdpackages --description "Change to the site-packages directory of the active virtualenv"
+function __vf_cdpackages --description "Change to the site-packages directory of this virtualenv"
 	vf cd
 	cd lib/python*/site-packages
 end
 
-function __vf_tmp --description "Create a temporary virtualenv that will be removed when deactivated"
+function __vf_tmp --description "Create a virtualenv that will be removed when deactivated"
 	set -l env_name (printf "%s%.4x" "tempenv-" (random) (random) (random))
     set -g VF_TEMPORARY_ENV
 
@@ -269,6 +262,19 @@ function __vf_connect --description "Connect this virtualenv to the current dire
     else
         echo "No virtualenv is active."
     end
+end
+
+function __vf_help --description "Print VirtualFish usage information (this information)"
+	echo "Usage: vf <command> [<args>]"
+	echo
+	echo "Available commands:"
+	echo
+	for sc in (functions -a | sed -n '/__vf_/{s///g;p;}')
+		set -l helptext (functions "__vf_$sc" | head -n 1 | sed -E "s|.*'(.*)'.*|\1|")
+		printf "    %-15s %s\n" $sc (set_color 555)$helptext(set_color normal)
+	end
+	echo
+	echo "For full documentation, see: http://virtualfish.readthedocs.org/en/latest/"
 end
 
 ################

--- a/virtual.fish
+++ b/virtual.fish
@@ -264,7 +264,7 @@ function __vf_connect --description "Connect this virtualenv to the current dire
     end
 end
 
-function __vf_help --description "Print VirtualFish usage information (this information)"
+function __vf_help --description "Print VirtualFish usage information"
 	echo "Usage: vf <command> [<args>]"
 	echo
 	echo "Available commands:"


### PR DESCRIPTION

- Add help subcommand for convenience/consistency 
  with other tools
- Make the --description text of all functions consistent and 
  under 80 char wide so that the help display looks nice
- Sort alphabetically the docs/usage.rst commands and make 
  references to 'currently-activated virtualenv' consistent

Address part of Issue #40 (most of it was already addressed :+1:  )