### PR TITLE
change documentation about to executing plugins in config.fish

### DIFF
--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -6,7 +6,7 @@ Virtualfish comes in-built with a number of plugins.
 You can use them by passing their names in as arguments to the virtualfish
 loader in your ``config.fish``, e.g.::
 
-   exec (python -m virtualfish auto_activation global_requirements)
+   eval (python -m virtualfish auto_activation global_requirements)
 
 .. _compat_aliases:
 


### PR DESCRIPTION
'exec' didn't work for me, but 'eval' did