### PR TITLE
refactor(compat_aliases.fish): use 'vf workon' in 'workon' alias

### DIFF
--- a/virtualfish/compat_aliases.fish
+++ b/virtualfish/compat_aliases.fish
@@ -2,7 +2,7 @@ function workon
     if not set -q argv[1]
         vf ls
     else
-        vf activate $argv[1]
+        vf workon $argv[1]
     end
 end
 function deactivate


### PR DESCRIPTION
The `workon env_name` alias calls `vf activate env_name` which does not change the working directory to the project directory. With this change, `workon env_name` changes the directory if there is a project associated with such environment.