### PR TITLE
Improvements to the projects plugin

### DIFF
--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -116,6 +116,8 @@ Commands
    switches to the respective project directory. If ``VIRTUALFISH_COMPAT_ALIASES``
    is set, ``workon`` is aliased to this command.
 
+-  ``vf lsprojects`` - List projects available in ``$PROJECT_HOME`` (see below)
+
 Configuration Variables
 .......................
 

--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -118,6 +118,11 @@ Commands
 
 -  ``vf lsprojects`` - List projects available in ``$PROJECT_HOME`` (see below)
 
+-  ``vf cdproject`` - Search for a project matching the name of the currently
+   activated virtualenv. If found, this switches to the respective project
+   directory. If ``VIRTUALFISH_COMPAT_ALIASES`` is set, ``cdproject`` is aliased
+   to this command.
+
 Configuration Variables
 .......................
 

--- a/virtualfish/projects.fish
+++ b/virtualfish/projects.fish
@@ -60,9 +60,25 @@ function __vf_lsprojects --description "List projects"
     popd
 end
 
+function __vf_cdproject --description "Change working directory to project directory"
+    if [ ! -d $PROJECT_HOME ]
+        return 2
+    end
+
+    if set -q VIRTUAL_ENV
+        set -l project_name (basename $VIRTUAL_ENV)
+        if [ -d $PROJECT_HOME/$project_name ]
+            cd $PROJECT_HOME/$project_name
+        end
+    end
+end
+
 if set -q VIRTUALFISH_COMPAT_ALIASES
     function mkproject
         vf project $argv
+    end
+    function cdproject
+        vf cdproject
     end
     function workon
         if not set -q argv[1]


### PR DESCRIPTION
This pull request includes two commits:

* docs(plugins): add description for the `vf lsprojects` command

* feat(projects plugin): add the `vf cdproject` command

  This command searches for a project matching the name of the currently
  activated virtualenv. If found, it switches to the respective project
  directory. If `VIRTUALFISH_COMPAT_ALIASES` is set, `cdproject` is
  aliased to this command.

  For more information:

  http://virtualenvwrapper.readthedocs.org/en/latest/command_ref.html#cdproject

Please review and comment.