### PR TITLE
Ensure PIP_USER is set to zero when creating a new virtualenv

### DIFF
--- a/virtualfish/virtual.fish
+++ b/virtualfish/virtual.fish
@@ -109,7 +109,7 @@ function __vf_new --description "Create a new virtualenv"
     if set -q VIRTUALFISH_DEFAULT_PYTHON
         set argv "--python" $VIRTUALFISH_DEFAULT_PYTHON $argv
     end
-	virtualenv $argv $VIRTUALFISH_HOME/$envname
+	env PIP_USER=0 virtualenv $argv $VIRTUALFISH_HOME/$envname
 	set vestatus $status
 	if begin; [ $vestatus -eq 0 ]; and [ -d $VIRTUALFISH_HOME/$envname ]; end
 		vf activate $envname


### PR DESCRIPTION
Since I prefer to install packages as user, I define PIP_USER=1 in my
environment (which is equivalent to passing '--user' to 'pip
install'). Since the flag can't be used to create a new virtualenv, we
explicitly set it to zero when calling 'virtualenv'.