### PR TITLE
feat(compat_aliases): add missing `lsvirtualenv`

### DIFF
--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -25,6 +25,7 @@ Commands
 -  ``mkvirtualenv [<options>] <envname>`` = ``vf new [<options>] <envname>``
 -  ``mktmpenv [<options>]`` = ``vf tmp [<options>]``
 -  ``rmvirtualenv`` = ``vf rm <envname>``
+-  ``lsvirtualenv`` = ``vf ls``
 -  ``cdvirtualenv`` = ``vf cd``
 -  ``cdsitepackages`` = ``vf cdpackages``
 -  ``add2virtualenv`` = ``vf addpath``

--- a/virtualfish/compat_aliases.fish
+++ b/virtualfish/compat_aliases.fish
@@ -26,6 +26,9 @@ function mkvirtualenv
 
     vf new $argv $env_name
 end
+function lsvirtualenv
+    vf ls
+end
 function rmvirtualenv
     vf rm $argv
 end


### PR DESCRIPTION
Quoting [lsvirtualenv](http://virtualenvwrapper.readthedocs.org/en/latest/command_ref.html#lsvirtualenv)'s command reference:
> **lsvirtualenv**
> 
> List all of the environments.