### PR TITLE
docs(usage): fix rst for list of commands

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -5,19 +5,19 @@ Commands
 --------
 
 -  ``vf new [<options>] <envname>`` - Create a virtualenv. Note that
-  ``<envname>`` *must be last*.
+   ``<envname>`` *must be last*.
 -  ``vf ls`` - List the available virtualenvs.
 -  ``vf activate <envname>`` - Activate a virtualenv. (Note: Doesn't use the
-  ``activate.fish`` script provided by virtualenv.)
+   ``activate.fish`` script provided by virtualenv.)
 -  ``vf deactivate`` - Deactivate the current virtualenv.
 -  ``vf rm <envname>`` - Delete a virtualenv.
 -  ``vf tmp [<options>]`` - Create a temporary virtualenv with a randomly
-  generated name that will be removed when it is deactivated.
+   generated name that will be removed when it is deactivated.
 -  ``vf cd`` - Change directory to currently-activated virtualenv.
 -  ``vf cdpackages`` - Change directory to the currently-activated virtualenv's
-  site-packages.
+   site-packages.
 -  ``vf addpath`` - Add a directory to this virtualenv's ``sys.path``.
-- ``vf all <command>`` - Run a command in all virtualenvs sequentially.
+-  ``vf all <command>`` - Run a command in all virtualenvs sequentially.
 
 If you're used to virtualenvwrapper's commands (``workon``, etc.), you may wish
 to enable the :ref:`compat_aliases` plugin.


### PR DESCRIPTION
Fix the documentation's reST syntax. I think the `readthedocs` should be updated too. I guess I love documentation :). 