### PR TITLE
Use __file__ to find find the module

### DIFF
--- a/virtualfish/__main__.py
+++ b/virtualfish/__main__.py
@@ -5,7 +5,7 @@ import inspect
 
 
 if __name__ == "__main__":
-    base_path = os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe())))
+    base_path = os.path.dirname(os.path.abspath(__file__))
     commands = ['. {}'.format(os.path.join(base_path, 'virtual.fish'))]
 
     for plugin in sys.argv[1:]:


### PR DESCRIPTION
`inspect.getfile(inspect.currentframe())` seems to return a relative path that
ends up with the virtualfish functions not being loaded.

Fixes #76 

After this fix:
```
nick@cumulus /> python2.7 -m virtualfish
. /usr/local/lib/python2.7/site-packages/virtualfish-1.0.0-py2.7.egg/virtualfish/virtual.fish;emit virtualfish_did_setup_plugins
nick@cumulus /> python3.5 -m virtualfish
. /usr/local/lib/python3.5/site-packages/virtualfish-1.0.0-py3.5.egg/virtualfish/virtual.fish;emit virtualfish_did_setup_plugins
```