### PR TITLE
Fix subcommand helptext

### DIFF
--- a/virtualfish/virtual.fish
+++ b/virtualfish/virtual.fish
@@ -288,7 +288,7 @@ function __vf_help --description "Print VirtualFish usage information"
     echo "Available commands:"
     echo
     for sc in (functions -a | sed -n '/__vf_/{s///g;p;}')
-        set -l helptext (functions "__vf_$sc" | head -n 1 | sed -E "s|.*'(.*)'.*|\1|")
+        set -l helptext (functions "__vf_$sc" | grep '^function ' | head -n 1 | sed -E "s|.*'(.*)'.*|\1|")
         printf "    %-15s %s\n" $sc (set_color 555)$helptext(set_color normal)
     end
     echo


### PR DESCRIPTION
```console
$ vf 
virtualfish 1.0.5

Usage: vf <command> [<args>]

Available commands:

    activate        # Defined in /home/joar/.local/lib/python3.5/site-packages/virtualfish/virtual.fish @ line 44
    addpath         # Defined in /home/joar/.local/lib/python3.5/site-packages/virtualfish/virtual.fish @ line 204
    all             # Defined in /home/joar/.local/lib/python3.5/site-packages/virtualfish/virtual.fish @ line 241
    cd              # Defined in /home/joar/.local/lib/python3.5/site-packages/virtualfish/virtual.fish @ line 177
    cdpackages      # Defined in /home/joar/.local/lib/python3.5/site-packages/virtualfish/virtual.fish @ line 185
    connect         # Defined in /home/joar/.local/lib/python3.5/site-packages/virtualfish/virtual.fish @ line 275
    deactivate      # Defined in /home/joar/.local/lib/python3.5/site-packages/virtualfish/virtual.fish @ line 86
    globalpackages  # Defined in /home/joar/.local/lib/python3.5/site-packages/virtualfish/virtual.fish @ line 298
    help            # Defined in /home/joar/.local/lib/python3.5/site-packages/virtualfish/virtual.fish @ line 283
    ls              # Defined in /home/joar/.local/lib/python3.5/site-packages/virtualfish/virtual.fish @ line 169
    new             # Defined in /home/joar/.local/lib/python3.5/site-packages/virtualfish/virtual.fish @ line 125
    requirements    # Defined in /home/joar/.local/lib/python3.5/site-packages/virtualfish/global_requirements.fish @ line 7
    rm              # Defined in /home/joar/.local/lib/python3.5/site-packages/virtualfish/virtual.fish @ line 156
    tmp             # Defined in /home/joar/.local/lib/python3.5/site-packages/virtualfish/virtual.fish @ line 190

For full documentation, see: http://virtualfish.readthedocs.org/en/1.0.5/
```
because 
https://github.com/joar/virtualfish/blob/80a44033b7facf069ddb734fb4e908a95e681b6c/virtualfish/virtual.fish#L291
assumes that `functions __vf_$sc` starts with `function __vf_$sc`, but it starts with `# Defined in <path> @ line <line>` for me on fish v2.6.0

```console
$ fish --version
fish, version 2.6.0
$ functions __vf_help 
# Defined in /home/joar/.local/lib/python3.5/site-packages/virtualfish/virtual.fish @ line 283
function __vf_help --description 'Print VirtualFish usage information'
[...]
```
