### PR TITLE
Make virtualfish work without installation

### DIFF
--- a/virtualfish/__main__.py
+++ b/virtualfish/__main__.py
@@ -5,10 +5,14 @@ import pkg_resources
 
 
 if __name__ == "__main__":
-    version = pkg_resources.get_distribution('virtualfish').version
+    try:
+        version = pkg_resources.get_distribution('virtualfish').version
+        commands = ['set -g VIRTUALFISH_VERSION {}'.format(version)]
+    except pkg_resources.DistributionNotFound:
+        commands = []
+
     base_path = os.path.dirname(os.path.abspath(__file__))
-    commands = [
-        'set -g VIRTUALFISH_VERSION {}'.format(version),
+    commands += [
         'set -g VIRTUALFISH_PYTHON_EXEC {}'.format(sys.executable),
         'source {}'.format(os.path.join(base_path, 'virtual.fish')),
     ]

--- a/virtualfish/virtual.fish
+++ b/virtualfish/virtual.fish
@@ -292,7 +292,13 @@ function __vf_help --description "Print VirtualFish usage information"
         printf "    %-15s %s\n" $sc (set_color 555)$helptext(set_color normal)
     end
     echo
-    echo "For full documentation, see: http://virtualfish.readthedocs.org/en/$VIRTUALFISH_VERSION/"
+
+    if set -q VIRTUALFISH_VERSION
+        set help_url "http://virtualfish.readthedocs.org/en/$VIRTUALFISH_VERSION/"
+    else
+        set help_url "http://virtualfish.readthedocs.org/en/latest/"
+    end
+    echo "For full documentation, see: $help_url"
 end
 
 function __vf_globalpackages --description "Toggle global site packages"


### PR DESCRIPTION
I want to keep my shell configuration in a git repository, and avoid manual installation steps as much as possible.

I store 'virtualenv' and 'virtualfish' as git submodules. 'virtualenv' works just fine when PYTHONPATH points to its repository. The only problem is 'virtualfish' requiring installation, just to show version information.