### PR TITLE
Add preliminary support for .project files

### DIFF
--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -113,6 +113,20 @@ the target virtualenv name, you can manually specify which virtualenv should be
 activated for a given project by creating a ``.venv`` file inside the project
 root containing the name of the corresponding virtualenv.
 
+If you use sub-folders, have projects located outside of ``PROJECT_HOME``, or
+utilize a project organization strategy that does not lend itself to storing
+all your projects in the root of a single directory, you may navigate to your
+project and associate the current working directory with the currently-activated
+virtual environment via the following example steps::
+
+   vf activate YourVirtualenv
+   cd /path/to/your/project
+   echo $PWD > $VIRTUALENV/.project
+
+In the future, you may then run ``vf workon YourVirtualenv`` to simultaneously
+activate ``YourVirtualenv`` and switch to the ``/path/to/your/project``
+directory.
+
 Commands
 ........
 

--- a/virtualfish/projects.fish
+++ b/virtualfish/projects.fish
@@ -91,7 +91,7 @@ if set -q VIRTUALFISH_COMPAT_ALIASES
         end
     end
 
-    complete -x -c workon -a "(ls $PROJECT_HOME)"
+    complete -x -c workon -a "(vf lsprojects)"
 end
 
-complete -x -c vf -n '__vfcompletion_using_command workon' -a "(ls $PROJECT_HOME)"
+complete -x -c vf -n '__vfcompletion_using_command workon' -a "(vf lsprojects)"

--- a/virtualfish/projects.fish
+++ b/virtualfish/projects.fish
@@ -14,7 +14,15 @@ function __vf_workon --description "Work on a project"
     # Matches a virtualenv name and possibly a project name
     if [ -d $VIRTUALFISH_HOME/$argv[1] ]
         vf activate $argv[1]
-        if [ -d $PROJECT_HOME/$argv[1] ]
+        if [ -e $VIRTUAL_ENV/.project ]
+            set -l project_file_path (cat $VIRTUAL_ENV/.project)
+            if [ -d $project_file_path ]
+                cd $project_file_path
+            else
+                echo ".project file path does not exist: $project_file_path"
+                return 2
+            end
+        else if [ -d $PROJECT_HOME/$argv[1] ]
             cd $PROJECT_HOME/$argv[1]
         end
     # Matches a project name but not a virtualenv name
@@ -61,14 +69,20 @@ function __vf_lsprojects --description "List projects"
 end
 
 function __vf_cdproject --description "Change working directory to project directory"
-    if [ ! -d $PROJECT_HOME ]
-        return 2
-    end
-
     if set -q VIRTUAL_ENV
-        set -l project_name (basename $VIRTUAL_ENV)
-        if [ -d $PROJECT_HOME/$project_name ]
-            cd $PROJECT_HOME/$project_name
+        if [ -e $VIRTUAL_ENV/.project ]
+            set -l project_file_path (cat $VIRTUAL_ENV/.project)
+            if [ -d $project_file_path ]
+                cd $project_file_path
+            else
+                echo ".project file path does not exist: $project_file_path"
+                return 2
+            end
+        else if [ -n "$PROJECT_HOME" ]
+            set -l project_name (basename $VIRTUAL_ENV)
+            if [ -d $PROJECT_HOME/$project_name ]
+                cd $PROJECT_HOME/$project_name
+            end
         end
     end
 end


### PR DESCRIPTION
Includes fix from @dwt for project completions when `PROJECT_HOME` is not set or available. See also: https://github.com/adambrenecki/virtualfish/pull/134